### PR TITLE
Reduce BLE memory usage. MicroBitEvent to enter pairing mode.

### DIFF
--- a/inc/MicroBit.h
+++ b/inc/MicroBit.h
@@ -172,6 +172,16 @@ class MicroBit
     static ManagedString getSerial();
 
     /**
+      * Return the model of the micro:bit
+      *
+      * @return A ManagedString representing the serial number of this device.
+      *
+      * @code
+      * ManagedString model = uBit.getModel();
+      */
+    ManagedString getModel();
+
+    /**
       * Will reset the micro:bit when called.
       *
       * @code

--- a/inc/MicroBit.h
+++ b/inc/MicroBit.h
@@ -85,7 +85,7 @@ class MicroBit
       * the compass and the accelerometer, where we only want to add them to the idle
       * fiber when someone has the intention of using these components.
       */
-    void                        onListenerRegisteredEvent(MicroBitEvent evt);
+    void                        onSystemEvent(MicroBitEvent evt);
 
     uint8_t                     status;
 

--- a/module.json
+++ b/module.json
@@ -4,7 +4,7 @@
   "description": "A simple to use collection of the most commonly used components in the micro:bit runtime",
   "license": "MIT",
   "dependencies": {
-    "microbit-dal": "lancaster-university/microbit-dal#whatami"
+    "microbit-dal": "microbit-sam/microbit-dal#whatami"
   },
   "extraIncludes": [
     "inc"

--- a/module.json
+++ b/module.json
@@ -4,7 +4,7 @@
   "description": "A simple to use collection of the most commonly used components in the micro:bit runtime",
   "license": "MIT",
   "dependencies": {
-    "microbit-dal": "microbit-sam/microbit-dal#whatami"
+    "microbit-dal": "lancaster-university/microbit-dal#dal-integration"
   },
   "extraIncludes": [
     "inc"

--- a/module.json
+++ b/module.json
@@ -4,7 +4,7 @@
   "description": "A simple to use collection of the most commonly used components in the micro:bit runtime",
   "license": "MIT",
   "dependencies": {
-    "microbit-dal": "lancaster-university/microbit-dal#dal-integration"
+    "microbit-dal": "lancaster-university/microbit-dal#whatami"
   },
   "extraIncludes": [
     "inc"

--- a/module.json
+++ b/module.json
@@ -4,7 +4,7 @@
   "description": "A simple to use collection of the most commonly used components in the micro:bit runtime",
   "license": "MIT",
   "dependencies": {
-    "microbit-dal": "lancaster-university/microbit-dal#v2.1.1"
+    "microbit-dal": "microbit-sam/microbit-dal#ble-dal-integration"
   },
   "extraIncludes": [
     "inc"

--- a/source/MicroBit.cpp
+++ b/source/MicroBit.cpp
@@ -120,7 +120,7 @@ void MicroBit::init()
     // Create an event handler to trap any handlers being created for I2C services.
     // We do this to enable initialisation of those services only when they're used,
     // which saves processor time, memeory and battery life.
-    messageBus.listen(MICROBIT_ID_ANY, MICROBIT_EVT_ANY, this, &MicroBit::onListenerRegisteredEvent);
+    messageBus.listen(MICROBIT_ID_SYSTEM, MICROBIT_EVT_ANY, this, &MicroBit::onSystemEvent);
 
     status |= MICROBIT_INITIALIZED;
 
@@ -206,7 +206,7 @@ void MicroBit::init()
   * the compass and the accelerometer, where we only want to add them to the idle
   * fiber when someone has the intention of using these components.
   */
-void MicroBit::onListenerRegisteredEvent(MicroBitEvent evt)
+void MicroBit::onSystemEvent(MicroBitEvent evt)
 {
     switch(evt.value)
     {

--- a/source/MicroBit.cpp
+++ b/source/MicroBit.cpp
@@ -165,7 +165,8 @@ void MicroBit::init()
             // Start the BLE stack, if it isn't already running.
             if (!ble)
             {
-                bleManager.init(getName(), getSerial(), messageBus, true, getModel());
+                ManagedString model = getModel();
+                bleManager.init(getName(), getSerial(), messageBus, true, model);
                 ble = bleManager.ble;
             }
 
@@ -196,7 +197,8 @@ void MicroBit::init()
     // Start the BLE stack, if it isn't already running.
     if (!ble)
     {
-        bleManager.init(getName(), getSerial(), messageBus, false, getModel());
+        ManagedString model = getModel();
+        bleManager.init(getName(), getSerial(), messageBus, false, model);
         ble = bleManager.ble;
     }
 #endif
@@ -254,11 +256,11 @@ ManagedString MicroBit::getModel()
 {
    switch(MicroBitAccelerometer::detectedAccelerometer->whatAmI())
    {
-        case 1:
+        case MICROBIT_ACCELEROMETER_MMA8653:
             return ManagedString(MICROBIT_MODEL_1_3_X);
             break;
-        case 2:
-        case 3:
+        case MICROBIT_ACCELEROMETER_LSM303:
+        case MICROBIT_ACCELEROMETER_FXOS87003:
             return ManagedString(MICROBIT_MODEL_1_5_X);
             break;
         default:

--- a/source/MicroBit.cpp
+++ b/source/MicroBit.cpp
@@ -260,7 +260,7 @@ ManagedString MicroBit::getModel()
             return ManagedString(MICROBIT_MODEL_1_3_X);
             break;
         case MICROBIT_ACCELEROMETER_LSM303:
-        case MICROBIT_ACCELEROMETER_FXOS87003:
+        case MICROBIT_ACCELEROMETER_FXOS8700:
             return ManagedString(MICROBIT_MODEL_1_5_X);
             break;
         default:

--- a/source/MicroBit.cpp
+++ b/source/MicroBit.cpp
@@ -121,7 +121,7 @@ void MicroBit::init()
     // Create an event handler to trap any handlers being created for I2C services.
     // We do this to enable initialisation of those services only when they're used,
     // which saves processor time, memeory and battery life.
-    messageBus.listen(MICROBIT_ID_MESSAGE_BUS_LISTENER, MICROBIT_EVT_ANY, this, &MicroBit::onListenerRegisteredEvent);
+    messageBus.listen(MICROBIT_ID_ANY, MICROBIT_EVT_ANY, this, &MicroBit::onListenerRegisteredEvent);
 
     status |= MICROBIT_INITIALIZED;
 
@@ -232,5 +232,17 @@ void MicroBit::onListenerRegisteredEvent(MicroBitEvent evt)
             // The thermometer uses lazy instantiation, we just need to read the data once to start it running.
             thermometer.updateSample();
             break;
+        #ifdef MICROBIT_BLE_PAIRING_MODE
+        case MICROBIT_ID_RESET_INTO_PAIRING:
+            // Reset the micro:bit into pairing mode
+            KeyValuePair* RebootMode = storage.get("RebootMode");
+            if(RebootMode == NULL){
+              uint8_t RebootModeValue = MICROBIT_MODE_PAIRING;
+              storage.put("RebootMode", &RebootModeValue, sizeof(RebootMode));
+              delete RebootMode;
+            }
+            microbit_reset();
+            break;
+        #endif
     }
 }


### PR DESCRIPTION
This PR will be in tandem with https://github.com/lancaster-university/microbit-dal/pull/409, it will probably easier to keep any discussion in there.

-----

Combines existing PRs #13 #6

Changes include:
-Partial flashing service: dynamically allocate block buffer
-Device Information Service: "BBC micro:bit" or "BBC micro:bit v1.3" or "BBC micro:bit v1.5"
-MicroBitEvent to restart into pairing mode

----

Even with these changes (+ local changes to Nordic BLE layer) the micro:bit still throws an 020 error when using all services - a build with all services apart from the UART works, but is probably running very close to running out of memory